### PR TITLE
CSS cleanup

### DIFF
--- a/plugins/cookieInvalidator.php
+++ b/plugins/cookieInvalidator.php
@@ -61,7 +61,7 @@ class cookieInvalidator {
 
 }
 
-if (isset($_COOKIE)) {
+if (isset($_COOKIE) && OFFSET_PATH != 2) {
 	cookieInvalidator::invalidate($_COOKIE);
 }
 ?>

--- a/themes/basic/styles/dark.css
+++ b/themes/basic/styles/dark.css
@@ -54,7 +54,7 @@ body {
 	padding-bottom: 14px;
 	margin-bottom: 20px;
 	/*min-height: 40px;
-  _height: 40px;*/
+	_height: 40px;*/
 }
 #gallerytitle h2 {
 	font-weight: normal;
@@ -122,22 +122,22 @@ blockquote {
 }
 
 #imagemetadata {
-  text-align: right;
+	text-align: right;
 }
 
 #imagemetadata table {
-  text-align: left;
-  line-height: 1em;
-  border: 1px solid #ccc;
-  top: 2em;
-  right: 0px;
-  background-color: #fafafa;
+	text-align: left;
+	line-height: 1em;
+	border: 1px solid #ccc;
+	top: 2em;
+	right: 0px;
+	background-color: #fafafa;
 }
 
 #imagemetadata table td {
-  border-bottom: 1px solid #f0f0f0;
-  background-color: #f8f8f8;
-  padding: 2px 5px;
+	border-bottom: 1px solid #f0f0f0;
+	background-color: #f8f8f8;
+	padding: 2px 5px;
 }
 
 
@@ -192,7 +192,7 @@ ul.pagelist li.next {
 }
 
 #exif_link {
-  float: right;
+	float: right;
 }
 
 /* Tags
@@ -261,7 +261,7 @@ span.tags_title {
 }
 .album {
 	margin: 0 12px 8px 0;
-  padding: 10px 8px 8px 10px;
+	padding: 10px 8px 8px 10px;
 	float: left;
 	width: 305px;
 	border: 1px solid #444;
@@ -450,11 +450,11 @@ label:hover {
 	position: fixed;
 	right: 0px;
 	top: 0px;
-	width: 120px;
+	width: 130px;
 	border-bottom: 1px solid #444;
 	border-left: 1px solid #444;
 	background: #222;
-	z-index: 2;
+	z-index: 2; 	text-align: left;
 }
 #admin_data{
 	top: 0px;
@@ -467,6 +467,7 @@ label:hover {
 	color: #aaa;
 	margin:0;
 	padding:0;
+	text-align: center;
 }
 #admin h3:hover { color: #86a1b6; }
 
@@ -497,8 +498,8 @@ label:hover {
 	top: 4px;
 }
 .clear {
-  clear:both;
-  height:10px;
+	clear:both;
+	height:10px;
 }
 
 /* Archive View

--- a/themes/basic/styles/light.css
+++ b/themes/basic/styles/light.css
@@ -459,13 +459,13 @@ label:hover {
 	padding-top: 20px;
 	z-index: 1;
 	line-height: 1.6em;
-
 }
 #admin h3 {
 	font-weight: normal;
 	color: #999;
 	margin:0;
-	padding:0; text-align: center;
+	padding:0;
+	text-align: center;
 }
 #admin h3:hover { color: #036; }
 

--- a/themes/basic/styles/sterile-dark.css
+++ b/themes/basic/styles/sterile-dark.css
@@ -23,8 +23,8 @@ body {
 	background: #333333;
 	-moz-border-radius: 10px;
 	-webkit-border-radius: 10px;
- 	-khtml-border-topright: 10px;
- 	border-radius: 10px;
+	-khtml-border-topright: 10px;
+	border-radius: 10px;
 	border: 1px solid #2a2a2a;
 }
 * html #main{width: 720px;}
@@ -48,14 +48,14 @@ body {
 	padding: 20px 10px 10px 20px;
 	-moz-border-radius: 10px 10px 0px 0px;
 	-webkit-border-radius: 10px 10px 0px 0px;
- 	-khtml-border-topright: 10px 10px 0px 0px;
- 	border-radius: 10px 10px 0px 0px;
+	-khtml-border-topright: 10px 10px 0px 0px;
+	border-radius: 10px 10px 0px 0px;
 	background: #c0db5a;
 	height:30px;
 	border-bottom: 1px solid #2a2a2a;
 }
 #padbox {
- 	padding: 20px !important;
+	padding: 20px !important;
 }
 
 #exif {
@@ -146,7 +146,7 @@ blockquote {
 }
 acronym {
 	cursor: help;
-  border-bottom: 1px solid;
+	border-bottom: 1px solid;
 }
 
 /* Page Navigation
@@ -414,7 +414,7 @@ label {
 
 .required {
 	color: #9C3;
-  cursor: help;
+	cursor: help;
 }
 
 .gravatar {
@@ -436,13 +436,17 @@ label {
 	position:fixed;
 	right:0;
 	top:0;
+	width: 130px;
 	border-left: 1px solid #2a2a2a;
 	border-bottom: 1px solid #2a2a2a;
 	background: #1a1a1a;
-	width:120px;
+	z-index: 2; 	text-align: left;
 }
 #admin_data{
-	top:20px;
+	top: 0px;
+	padding-top: 20px;
+	z-index: 1;
+	line-height: 1.6em;
 }
 #admin h3 {
 	font: 100% Arial, "Helvetica Neue", Helvetica, sans-serif;
@@ -451,6 +455,7 @@ label {
 	border-bottom: 1px dashed #2a2a2a;
 	margin:0;
 	padding:0;
+	text-align: center;
 }
 
 /* Search Box
@@ -467,8 +472,8 @@ label {
 	margin:0px;
 }
 #search input.button {
-  padding: 1px;
-  font-size: 80%;
+	padding: 1px;
+	font-size: 80%;
 }
 #search a {
 	text-decoration: none;
@@ -485,8 +490,8 @@ label {
 	top: 4px;
 }
 .clear {
-  clear:both;
-  height:10px;
+	clear:both;
+	height:10px;
 }
 
 /* Archive View

--- a/themes/basic/styles/sterile-light.css
+++ b/themes/basic/styles/sterile-light.css
@@ -23,8 +23,8 @@ body {
 	background: #FFF;
 	-moz-border-radius: 10px;
 	-webkit-border-radius: 10px;
- 	-khtml-border-radius: 10px;
- 	border-radius: 10px;
+	-khtml-border-radius: 10px;
+	border-radius: 10px;
 	border: 1px solid #CCC;
 }
 * html #main{width: 720px;}
@@ -48,8 +48,8 @@ body {
 	padding: 20px 10px 10px 20px;
 	-moz-border-radius: 10px 10px 0px 0px;
 	-webkit-border-radius: 10px 10px 0px 0px;
- 	-khtml-border-topright: 10px 10px 0px 0px;
- 	border-radius: 10px 10px 0px 0px;
+	-khtml-border-topright: 10px 10px 0px 0px;
+	border-radius: 10px 10px 0px 0px;
 	background: #F8F8F8;
 	height:30px;
 	border-bottom: 1px solid #CCC;
@@ -470,16 +470,20 @@ label {
 /* Admin Toolbox
 ------------------------------ */
 #admin, #admin_data{
-	position:fixed;
-	right:0;
-	top:0;
+	position: fixed;
+	right: 0px;
+	top: 0px;
+	width: 130px;
 	border-left: 1px solid #CCC;
 	border-bottom: 1px solid #CCC;
 	background: #fff;
-	width:120px;
+	z-index: 2; 	text-align: left;
 }
 #admin_data{
-	top:16px;
+	top: 0px;
+	padding-top: 20px;
+	z-index: 1;
+	line-height: 1.6em;
 }
 #admin h3 {
 	font: 100% Arial, "Helvetica Neue", Helvetica, sans-serif;
@@ -488,6 +492,7 @@ label {
 	border-bottom: 1px dashed #CCC;
 	margin:0;
 	padding:0;
+	text-align: center;
 }
 /* Search Box
 ------------------------------ */

--- a/zp-core/template-functions.php
+++ b/zp-core/template-functions.php
@@ -46,7 +46,6 @@ function printThemeHeadItems() {
 	<?php
 	if (zp_loggedin()) {
 		?>
-		<link rel="stylesheet" href="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/toolbox.css" type="text/css" />
 		<script type="text/javascript">
 			// <!-- <![CDATA[
 			var deleteAlbum1 = "<?php echo gettext("Are you sure you want to delete this entire album?"); ?>";
@@ -3859,39 +3858,39 @@ function printSearchForm($prevtext = NULL, $id = 'search', $buttonSource = NULL,
 		<!-- search form -->
 		<form method="post" action="<?php echo $searchurl; ?>" id="search_form">
 			<script type="text/javascript">
-				// <!-- <![CDATA[
-				var within = <?php echo (int) $within; ?>;
-				function search_(way) {
-					within = way;
-					if (way) {
-						$('#search_submit').attr('title', '<?php echo sprintf($hint, $buttontext); ?>');
-					} else {
-						lastsearch = '';
-						$('#search_submit').attr('title', '<?php echo $buttontext; ?>');
-					}
-					$('#search_input').val('');
-				}
-				$('#search_form').submit(function () {
-					if (within) {
-						var newsearch = $.trim($('#search_input').val());
-						if (newsearch.substring(newsearch.length - 1) == ',') {
-							newsearch = newsearch.substr(0, newsearch.length - 1);
-						}
-						if (newsearch.length > 0) {
-							$('#search_input').val('(<?php echo $searchwords; ?>) AND (' + newsearch + ')');
+					// <!-- <![CDATA[
+					var within = <?php echo (int) $within; ?>;
+					function search_(way) {
+						within = way;
+						if (way) {
+							$('#search_submit').attr('title', '<?php echo sprintf($hint, $buttontext); ?>');
 						} else {
-							$('#search_input').val('<?php echo $searchwords; ?>');
+							lastsearch = '';
+							$('#search_submit').attr('title', '<?php echo $buttontext; ?>');
 						}
+						$('#search_input').val('');
 					}
-					return true;
-				});
-				function search_all() {
-					//search all is copyright by Stephen Billard for use in ZenPhoto20. All rights reserved
-					var check = $('#SEARCH_checkall').prop('checked');
-					$('.SEARCH_checkall').prop('checked', check);
-				}
+					$('#search_form').submit(function () {
+						if (within) {
+							var newsearch = $.trim($('#search_input').val());
+							if (newsearch.substring(newsearch.length - 1) == ',') {
+								newsearch = newsearch.substr(0, newsearch.length - 1);
+							}
+							if (newsearch.length > 0) {
+								$('#search_input').val('(<?php echo $searchwords; ?>) AND (' + newsearch + ')');
+							} else {
+								$('#search_input').val('<?php echo $searchwords; ?>');
+							}
+						}
+						return true;
+					});
+					function search_all() {
+						//search all is copyright by Stephen Billard for use in ZenPhoto20. All rights reserved
+						var check = $('#SEARCH_checkall').prop('checked');
+						$('.SEARCH_checkall').prop('checked', check);
+					}
 
-				// ]]> -->
+					// ]]> -->
 			</script>
 			<?php echo $prevtext; ?>
 			<div>


### PR DESCRIPTION
Note that this reverts dfa92a94524916bf92f2ce968e0a78d3432c89fe. The
code to check if the admin toolbox CSS existed was too costly (upwards
to 6 seconds depending on the number and size of CSS files loaded.)

Instead themes may choose to load the default CSS from the zp-core
folder or include the definitions within their local CSS files.