### PR TITLE
Comment Form checkbox update

### DIFF
--- a/zp-core/zp-extensions/comment_form/comment_form.php
+++ b/zp-core/zp-extensions/comment_form/comment_form.php
@@ -100,8 +100,8 @@
 		<p>
 			<label for="private">
 				<?php echo gettext("Private comment (do not publish)"); ?>
-				<input type="checkbox" id="private" name="private" value="1"<?php if ($stored['private']) echo ' checked="checked"'; ?> />
 			</label>
+			<input type="checkbox" id="private" name="private" value="1"<?php if ($stored['private']) echo ' checked="checked"'; ?> />
 		</p>
 		<?php
 	}


### PR DESCRIPTION
Move comment form "private" checkbox outside of label to allow better
CSS positioning using float.