### PR TITLE
Add CSS class to input fields in Contact form

### DIFF
--- a/zp-core/lib-auth.php
+++ b/zp-core/lib-auth.php
@@ -1262,7 +1262,7 @@ class Zenphoto_Authority {
 			$x = '';
 		}
 		?>
-		<input type="hidden" name="passrequired<?php echo $id; ?>" id="passrequired-<?php echo $id; ?>" value="<?php echo (int) $required; ?>" />
+		<input type="hidden" name="passrequired<?php echo $id; ?>" id="passrequired-<?php echo $id; ?>" value="<?php echo (int) $required; ?>" class="inputbox"/>
 		<p>
 			<label for="pass<?php echo $id; ?>" id="strength<?php echo $id; ?>"><?php echo gettext("Password") . $flag; ?></label>
 			<input type="password" size="<?php echo TEXT_INPUT_SIZE; ?>"
@@ -1271,7 +1271,7 @@ class Zenphoto_Authority {
 						 onchange="$('#passrequired-<?php echo $id; ?>').val(1);"
 						 onclick="passwordClear('<?php echo $id; ?>');"
 						 onkeyup="passwordStrength('<?php echo $id; ?>');"
-						 <?php echo $disable; ?> />
+						 <?php echo $disable; ?> class="inputbox"/>
 		</p>
 		<p>
 			<label for="disclose_password<?php echo $id; ?>"><?php echo gettext('Show password'); ?></label>
@@ -1285,7 +1285,7 @@ class Zenphoto_Authority {
 						 id="pass_r<?php echo $id; ?>" disabled="disabled"
 						 onchange="$('#passrequired-<?php echo $id; ?>').val(1);"
 						 onkeydown="passwordClear('<?php echo $id; ?>');"
-						 onkeyup="passwordMatch('<?php echo $id; ?>');" />
+						 onkeyup="passwordMatch('<?php echo $id; ?>');" class="inputbox"/>
 		</p>
 		<?php
 	}

--- a/zp-core/zp-extensions/contact_form/form.php
+++ b/zp-core/zp-extensions/contact_form/form.php
@@ -13,7 +13,7 @@
 		?>
 		<p>
 			<label for="title"><?php printf(gettext("Title%s"), checkRequiredField(getOption('contactform_title'))); ?></label>
-			<input type="text" id="title" name="title" size="50" value="<?php echo html_encode($mailcontent['title']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="title" name="title" size="50" value="<?php echo html_encode($mailcontent['title']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -21,7 +21,7 @@
 		?>
 		<p>
 			<label for="name"><?php printf(gettext("Name%s"), checkRequiredField(getOption('contactform_name'))); ?></label>
-			<input type="text" id="name" name="name" size="50" value="<?php echo html_encode($mailcontent['name']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="name" name="name" size="50" value="<?php echo html_encode($mailcontent['name']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -35,7 +35,7 @@
 		?>
 		<p>
 			<label for="company"><?php printf(gettext("Company%s"), checkRequiredField(getOption('contactform_company'))); ?></label>
-			<input type="text" id="company" name="company" size="50" value="<?php echo html_encode($mailcontent['company']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="company" name="company" size="50" value="<?php echo html_encode($mailcontent['company']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -43,7 +43,7 @@
 		?>
 		<p>
 			<label for="street"><?php printf(gettext("Street%s"), checkRequiredField(getOption('contactform_street'))); ?></label>
-			<input type="text" id="street" name="street" size="50" value="<?php echo html_encode($mailcontent['street']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="street" name="street" size="50" value="<?php echo html_encode($mailcontent['street']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -51,7 +51,7 @@
 		?>
 		<p>
 			<label for="city"><?php printf(gettext("City%s"), checkRequiredField(getOption('contactform_city'))); ?></label>
-			<input type="text" id="city" name="city" size="50" value="<?php echo html_encode($mailcontent['city']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="city" name="city" size="50" value="<?php echo html_encode($mailcontent['city']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -59,7 +59,7 @@
 		?>
 		<p>
 			<label for="state"><?php printf(gettext("State%s"), checkRequiredField(getOption('contactform_state'))); ?></label>
-			<input type="text" id="state" name="state" size="50" value="<?php echo html_encode($mailcontent['city']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="state" name="state" size="50" value="<?php echo html_encode($mailcontent['city']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -67,7 +67,7 @@
 		?>
 		<p>
 			<label for="country"><?php printf(gettext("Country%s"), checkRequiredField(getOption('contactform_country'))); ?></label>
-			<input type="text" id="country" name="country" size="50" value="<?php echo html_encode($mailcontent['country']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="country" name="country" size="50" value="<?php echo html_encode($mailcontent['country']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -75,7 +75,7 @@
 		?>
 		<p>
 			<label for="postal"><?php printf(gettext("Postal code%s"), checkRequiredField(getOption('contactform_postal'))); ?></label>
-			<input type="text" id="postal" name="postal" size="50" value="<?php echo html_encode($mailcontent['postal']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="postal" name="postal" size="50" value="<?php echo html_encode($mailcontent['postal']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -83,7 +83,7 @@
 		?>
 		<p>
 			<label for="email"><?php printf(gettext("E-Mail%s"), checkRequiredField(getOption('contactform_email'))); ?></label>
-			<input type="text" id="email" name="email" size="50" value="<?php echo html_encode($mailcontent['email']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="email" name="email" size="50" value="<?php echo html_encode($mailcontent['email']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -91,7 +91,7 @@
 		?>
 		<p>
 			<label for="website"><?php printf(gettext("Website%s"), checkRequiredField(getOption('contactform_website'))); ?></label>
-			<input type="text" id="website" name="website" size="50" value="<?php echo html_encode($mailcontent['website']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="website" name="website" size="50" value="<?php echo html_encode($mailcontent['website']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -99,7 +99,7 @@
 		?>
 		<p>
 			<label for="phone"><?php printf(gettext("Phone%s"), checkRequiredField(getOption('contactform_phone'))); ?></label>
-			<input type="text" id="phone" name="phone" size="50" value="<?php echo html_encode($mailcontent['phone']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+			<input type="text" id="phone" name="phone" size="50" value="<?php echo html_encode($mailcontent['phone']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 		</p>
 		<?php
 	}
@@ -121,11 +121,11 @@
 	?>
 	<p>
 		<label for="subject"><?php echo gettext("Subject<strong>*</strong>"); ?></label>
-		<input type="text" id="subject" name="subject" size="50" value="<?php echo html_encode($mailcontent['subject']); ?>"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
+		<input type="text" id="subject" name="subject" size="50" value="<?php echo html_encode($mailcontent['subject']); ?>" class="inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?> />
 	</p>
 	<p class="mailmessage">
 		<label for="message"><?php echo gettext("Message<strong>*</strong>"); ?></label>
-		<textarea id="message" name="message" <?php if ($_processing_post) echo ' disabled="disabled"'; ?>><?php echo $mailcontent['message']; ?></textarea>
+		<textarea id="message" name="message"  class="textarea_inputbox"<?php if ($_processing_post) echo ' disabled="disabled"'; ?>><?php echo $mailcontent['message']; ?></textarea>
 	</p>
 	<?php
 	if (!$_processing_post) {

--- a/zp-core/zp-extensions/register_user/register_user_form.php
+++ b/zp-core/zp-extensions/register_user/register_user_form.php
@@ -13,7 +13,7 @@ $action = preg_replace('/\?verify=(.*)/', '', getRequestURI());
 		<input type="hidden" name="register_user" value="yes" />
 		<p style="display:none;">
 			<label for="username"><?php echo gettext("Username* (this will be your user username)"); ?></label>
-			<input type="text" id="username" name="username" value="" size="<?php echo TEXT_INPUT_SIZE; ?>" />
+			<input type="text" id="username" name="username" value="" size="<?php echo TEXT_INPUT_SIZE; ?>" class="inputbox" />
 		</p>
 		<p>
 			<label for="adminuser">
@@ -25,19 +25,19 @@ $action = preg_replace('/\?verify=(.*)/', '', getRequestURI());
 				}
 				?>
 			</label>
-			<input type="text" id="adminuser" name="user" value="<?php echo html_encode($user); ?>" size="<?php echo TEXT_INPUT_SIZE; ?>" />
+			<input type="text" id="adminuser" name="user" value="<?php echo html_encode($user); ?>" size="<?php echo TEXT_INPUT_SIZE; ?>" class="inputbox"/>
 		</p>
 		<?php $_zp_authority->printPasswordForm(NULL, false, NULL, false, $flag = '<strong>*</strong>'); ?>
 		<p>
 			<label for="admin_name"><?php echo gettext("Name"); ?><strong>*</strong></label>
-			<input type="text" id="admin_name" name="admin_name" value="<?php echo html_encode($admin_n); ?>" size="<?php echo TEXT_INPUT_SIZE; ?>" />
+			<input type="text" id="admin_name" name="admin_name" value="<?php echo html_encode($admin_n); ?>" size="<?php echo TEXT_INPUT_SIZE; ?>" class="inputbox"/>
 		</p>
 		<?php
 		if (!getOption('register_user_email_is_id')) {
 			?>
 			<p>
 				<label for="admin_email"><?php echo gettext("Email"); ?><?php if (!$emailid) echo '<strong>*</strong>'; ?></label>
-				<input type="text" id="admin_email" name="admin_email" value="<?php echo html_encode($admin_e); ?>" size="<?php echo TEXT_INPUT_SIZE; ?>" />
+				<input type="text" id="admin_email" name="admin_email" value="<?php echo html_encode($admin_e); ?>" size="<?php echo TEXT_INPUT_SIZE; ?>" class="inputbox"/>
 			</p>
 			<?php
 		}
@@ -58,31 +58,31 @@ $action = preg_replace('/\?verify=(.*)/', '', getRequestURI());
 					<label for="comment_form_street">
 						<?php printf(gettext('Street%s'), $required); ?>
 					</label>
-					<input type="text" name="0-comment_form_street" id="comment_form_street" class="inputbox" size="40" value="<?php echo $address['street']; ?>">
+					<input type="text" name="0-comment_form_street" id="comment_form_street" class="inputbox" size="40" value="<?php echo $address['street']; ?>" class="inputbox">
 				</p>
 				<p>
 					<label for="comment_form_city">
 						<?php printf(gettext('City%s'), $required); ?>
 					</label>
-					<input type="text" name="0-comment_form_city" id="comment_form_city" class="inputbox" size="40" value="<?php echo $address['city']; ?>">
+					<input type="text" name="0-comment_form_city" id="comment_form_city" class="inputbox" size="40" value="<?php echo $address['city']; ?>" class="inputbox">
 				</p>
 				<p>
 					<label for="comment_form_state">
 						<?php printf(gettext('State%s'), $required); ?>
 					</label>
-					<input type="text" name="0-comment_form_state" id="comment_form_state" class="inputbox" size="40" value="<?php echo $address['state']; ?>">
+					<input type="text" name="0-comment_form_state" id="comment_form_state" class="inputbox" size="40" value="<?php echo $address['state']; ?>" class="inputbox">
 				</p>
 				<p>
 					<label for="comment_form_country">
 						<?php printf(gettext('Country%s'), $required); ?>
 					</label>
-					<input type="text" name="0-comment_form_country" id="comment_form_country" class="inputbox" size="40" value="<?php echo $address['country']; ?>">
+					<input type="text" name="0-comment_form_country" id="comment_form_country" class="inputbox" size="40" value="<?php echo $address['country']; ?>" class="inputbox">
 				</p>
 				<p>
 					<label for="comment_form_postal">
 						<?php printf(gettext('Postal code%s'), $required); ?>
 					</label>
-					<input type="text" name="0-comment_form_postal" id="comment_form_postal" class="inputbox" size="40" value="<?php echo $address['postal']; ?>">
+					<input type="text" name="0-comment_form_postal" id="comment_form_postal" class="inputbox" size="40" value="<?php echo $address['postal']; ?>" class="inputbox">
 				</p>
 				<?php
 			}


### PR DESCRIPTION
Add CSS classes to the input and text fields of the contact_us plugin
form to allow easier setting of styles. Followed example of comment
form.