### PR TITLE
Statistics update

### DIFF
--- a/zp-core/locale/fr_FR/LC_MESSAGES/statistics.txt
+++ b/zp-core/locale/fr_FR/LC_MESSAGES/statistics.txt
@@ -1,9 +1,9 @@
 * Translation                                           Items                Words
-Translated                                        4777 (91 %)                38360
+Translated                                       4763 (100 %)                30000
 Needs review (fuzzy)                                  1 (0 %)                   10
 Translations with errors                                    0
 
  *Source Text
-Strings in source language                               5277                36426
-Needs review (fuzzy)                                                             9
-Not translated                                      499 (9 %)                 3976
+Strings in source language                               4764                28818
+Needs review (fuzzy)                                        1                    9
+Not translated                                              0


### PR DESCRIPTION
Hello,

I have updated the Statistics file. I do not have Poedit Pro, just the free version which doesn't include statistics, so I used another translation program, Virtaal, to count the number of strings.
Numbers I see slightly disagree between the two programs. Both are wrong in French in that they consider accented letters as word separators (hence "générosité" is 6 words).

Regards,