### PR TITLE
Admin Toolbox style tweak

### DIFF
--- a/zp-core/template-functions.php
+++ b/zp-core/template-functions.php
@@ -65,7 +65,7 @@ function adminToolbox() {
 			$name = $_zp_current_admin_obj->getUser();
 		}
 		?>
-		<div id="<?php echo $id; ?>" style="margin-right: 10px;">
+		<div id="<?php echo $id; ?>">
 			<a onclick="$('#<?php echo $dataid; ?>').toggle();" title="<?php echo gettext('Logged in as') . ' ' . $name; ?>" style="text-decoration: none;">
 				<span class="adminGear">
 					<?php echo GEAR_SYMBOL; ?>

--- a/zp-core/toolbox.css
+++ b/zp-core/toolbox.css
@@ -15,6 +15,7 @@ Default admin toolbox css
 	text-align: center !important;
 	padding-top: 5px !important;
 	padding-left: 5px !important;
+	margin-right: 10px;
 }
 #admin_tb_data{
 	position: fixed;


### PR DESCRIPTION
Move the inline style to the toolbox.css file. Easier for theme designer to modify with their own css.